### PR TITLE
openWEMI.ttl - add closing period to prefix

### DIFF
--- a/openWEMI.ttl
+++ b/openWEMI.ttl
@@ -1,4 +1,4 @@
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> 
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .


### PR DESCRIPTION
The first prefix definition lacks a closing period, which makes it unparsable with, say, rapper. This pull request simply adds that period.